### PR TITLE
Use jcommander instead of apache commons-cli in workload module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ for client libraries to work.
  
     ```
     $ mvn clean compile assembly:single
-    $ java -jar target/workload-1.0-SNAPSHOT-jar-with-dependencies.jar --address-name localhost --port 8080 --num-accounts 200 
+    $ java -jar target/workload-1.0-SNAPSHOT-jar-with-dependencies.jar \
+        --address-name localhost --port 8080 --thread-count 200 
     ```
 
 ## How to run the application tests

--- a/pom.xml
+++ b/pom.xml
@@ -79,11 +79,6 @@
                 <version>3.8.0</version>
                 <scope>compile</scope>
             </dependency>
-            <dependency>
-                <groupId>commons-cli</groupId>
-                <artifactId>commons-cli</artifactId>
-                <version>1.4</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,12 @@
         <grpc.version>1.38.0</grpc.version>
     </properties>
 
+    <!--
+        Shared dependencies inheritable by child modules. These are not
+        inherited by default. Child modules need to explicitly specify a
+        dependency in their dependencies section using only groupId and
+        artifactId.
+    -->
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -29,6 +35,54 @@
                 <version>${grpc.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <artifactId>libraries-bom</artifactId>
+                <groupId>com.google.cloud</groupId>
+                <scope>import</scope>
+                <type>pom</type>
+                <version>20.3.0</version>
+            </dependency>
+            <dependency>
+                <artifactId>junit</artifactId>
+                <groupId>junit</groupId>
+                <scope>test</scope>
+                <version>4.13.1</version>
+            </dependency>
+            <dependency>
+                <artifactId>jcommander</artifactId>
+                <groupId>com.beust</groupId>
+                <version>1.81</version>
+            </dependency>
+            <dependency>
+                <artifactId>truth</artifactId>
+                <groupId>com.google.truth</groupId>
+                <scope>test</scope>
+                <version>1.1.3</version>
+            </dependency>
+            <dependency>
+                <!-- for java 9+ -->
+                <artifactId>annotations-api</artifactId>
+                <groupId>org.apache.tomcat</groupId>
+                <scope>provided</scope>
+                <version>6.0.53</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-core-bom</artifactId>
+                <version>1.95.2</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-qual</artifactId>
+                <version>3.8.0</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>commons-cli</groupId>
+                <artifactId>commons-cli</artifactId>
+                <version>1.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -40,6 +94,22 @@
                 <version>1.6.2</version>
             </extension>
         </extensions>
+        <!--
+            Shared plugins inheritable by child modules. These are not
+            inherited by default. Child modules need to explicitly specify
+            these plugins in build/plugins to inherit them using only groupId
+            and artifactId, with additional configurations as necessary.
+        -->
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <version>3.0.0-M5</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <!-- Common plugins inherited by all child modules -->
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -48,6 +118,7 @@
                     <target>8</target>
                 </configuration>
                 <groupId>org.apache.maven.plugins</groupId>
+                <version>3.8.1</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -14,47 +14,18 @@
     <name>server</name>
     <version>1.0-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <artifactId>libraries-bom</artifactId>
-                <groupId>com.google.cloud</groupId>
-                <scope>import</scope>
-                <type>pom</type>
-                <version>20.3.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
-        <!--spanner JDBC dependency -->
         <dependency>
             <artifactId>google-cloud-spanner-jdbc</artifactId>
             <groupId>com.google.cloud</groupId>
         </dependency>
-        <!-- testing -->
         <dependency>
             <artifactId>junit</artifactId>
             <groupId>junit</groupId>
-            <scope>test</scope>
-            <version>4.13.1</version>
         </dependency>
-        <!-- spanner dependency -->
         <dependency>
             <artifactId>google-cloud-spanner</artifactId>
             <groupId>com.google.cloud</groupId>
-        </dependency>
-
-        <dependency>
-            <artifactId>guava</artifactId>
-            <groupId>com.google.guava</groupId>
-            <version>30.1.1-jre</version>
-        </dependency>
-
-        <dependency>
-            <artifactId>protobuf-java</artifactId>
-            <groupId>com.google.protobuf</groupId>
-            <version>3.16.0</version>
         </dependency>
         <dependency>
             <artifactId>grpc-netty-shaded</artifactId>
@@ -83,27 +54,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <!-- necessary for Java 9+ -->
-            <artifactId>annotations-api</artifactId>
-            <groupId>org.apache.tomcat</groupId>
-            <scope>provided</scope>
-            <version>6.0.53</version>
-        </dependency>
-        <dependency>
-            <artifactId>guice</artifactId>
-            <groupId>com.google.inject</groupId>
-            <version>5.0.1</version>
-        </dependency>
-        <dependency>
             <artifactId>jcommander</artifactId>
             <groupId>com.beust</groupId>
-            <version>1.81</version>
-        </dependency>
-        <dependency>
-            <artifactId>junit-jupiter-params</artifactId>
-            <groupId>org.junit.jupiter</groupId>
-            <scope>test</scope>
-            <version>5.7.0</version>
         </dependency>
         <dependency>
             <artifactId>google-cloud-spanner</artifactId>
@@ -114,26 +66,11 @@
         <dependency>
             <artifactId>truth</artifactId>
             <groupId>com.google.truth</groupId>
-            <scope>test</scope>
-            <version>1.1.3</version>
         </dependency>
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <artifactId>os-maven-plugin</artifactId>
-                <groupId>kr.motd.maven</groupId>
-                <version>1.6.2</version>
-            </extension>
-        </extensions>
         <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
@@ -167,22 +104,6 @@
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.xolstice.maven.plugins</groupId>
-                <artifactId>protobuf-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <artifactId>fmt-maven-plugin</artifactId>
-                <groupId>com.coveo</groupId>
-                <version>2.11</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>format</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/server/src/main/java/com/google/finapp/FinAppService.java
+++ b/server/src/main/java/com/google/finapp/FinAppService.java
@@ -18,7 +18,6 @@ import com.google.cloud.ByteArray;
 import com.google.cloud.Timestamp;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.inject.Inject;
 import com.google.protobuf.ByteString;
 import io.grpc.Status;
 import io.grpc.StatusException;
@@ -30,7 +29,6 @@ final class FinAppService extends FinAppGrpc.FinAppImplBase {
 
   private final SpannerDaoInterface spannerDao;
 
-  @Inject
   FinAppService(SpannerDaoInterface spannerDao) {
     this.spannerDao = spannerDao;
   }

--- a/workload/pom.xml
+++ b/workload/pom.xml
@@ -33,11 +33,8 @@
             <artifactId>grpc-protobuf</artifactId>
         </dependency>
         <dependency>
-            <!-- necessary for Java 9+ -->
             <artifactId>annotations-api</artifactId>
             <groupId>org.apache.tomcat</groupId>
-            <scope>provided</scope>
-            <version>6.0.53</version>
         </dependency>
         <dependency>
             <artifactId>grpc-netty-shaded</artifactId>
@@ -46,35 +43,19 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-core</artifactId>
-            <version>1.95.2</version>
         </dependency>
         <dependency>
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
-            <version>3.8.0</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
         </dependency>
-
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.6.1</version>
-            </extension>
-        </extensions>
         <plugins>
-            <plugin>
-                <groupId>org.xolstice.maven.plugins</groupId>
-                <artifactId>protobuf-maven-plugin</artifactId>
-            </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>

--- a/workload/pom.xml
+++ b/workload/pom.xml
@@ -48,10 +48,6 @@
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Fixes #51

For consistency with server module. Discussion around jcommander vs apache is at https://github.com/GoogleCloudPlatform/cloud-spanner-samples/pull/22#discussion_r681220662.